### PR TITLE
Remove args parameter when call hooks.

### DIFF
--- a/lib/resque/job.rb
+++ b/lib/resque/job.rb
@@ -157,7 +157,7 @@ module Resque
         # Resque::DontPerform is raised.
         begin
           before_hooks.each do |hook|
-            job.send(hook, *job_args)
+            job.send(hook)
           end
         rescue DontPerform
           return false
@@ -173,11 +173,11 @@ module Resque
           stack = around_hooks.reverse.inject(nil) do |last_hook, hook|
             if last_hook
               lambda do
-                job.send(hook, *job_args) { last_hook.call }
+                job.send(hook) { last_hook.call }
               end
             else
               lambda do
-                job.send(hook, *job_args) do
+                job.send(hook) do
                   result = job.perform(*job_args)
                   job_was_performed = true
                   result
@@ -190,7 +190,7 @@ module Resque
 
         # Execute after_perform hook
         after_hooks.each do |hook|
-          job.send(hook, *job_args)
+          job.send(hook)
         end
 
         # Return true if the job was performed


### PR DESCRIPTION
I am using rails 5.2.
The second parameter for `ActiveJob::Callbacks.before_perform` is the `*filters`.

```ruby
def before_perform(*filters, &blk)
  set_callback(:perform, :before, *filters, &blk)
end
```
But Resque hooks code send *args parameter.
```ruby
before_hooks.each do |hook|
    job.send(hook, *args)
end
```

This code raise ArgumentError exception.
```ruby
class Callback #:nodoc:#
        def self.build(chain, filter, kind, options)
          if filter.is_a?(String)
            raise ArgumentError, <<-MSG.squish
              Passing string to define a callback is not supported. See the `.set_callback`
              documentation to see supported values.
            MSG
          end

          new chain.name, filter, kind, options, chain.config
        end
...
end
```

So I remove *args parameter.